### PR TITLE
v0.1.5 - Custom Setting Name Too Long Bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 ## Deployment
 
-<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6sAAAS">
+<a href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Oa2hAAC">
   <img alt="Deploy to Salesforce"
        src="./media/deploy-package-to-prod.png">
 </a>
 
-<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008C6sAAAS">
+<a href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t6g000008Oa2hAAC">
   <img alt="Deploy to Salesforce Sandbox"
        src="./media/deploy-package-to-sandbox.png">
 </a>

--- a/core/classes/FlowRoundRobinAssigner.cls
+++ b/core/classes/FlowRoundRobinAssigner.cls
@@ -20,6 +20,8 @@ global without sharing class FlowRoundRobinAssigner {
     global SObject recordToRoundRobin;
     @InvocableVariable(label='Update records - defaults to false')
     global Boolean updateRecords = false;
+    @InvocableVariable(label='Name For Custom Setting Record')
+    global String optionalName;
   }
 
   @InvocableMethod(category='Round Robin' label='Round robin records')
@@ -87,7 +89,9 @@ global without sharing class FlowRoundRobinAssigner {
 
   private RoundRobinAssigner.Details getAssignmentDetails(FlowInput input) {
     RoundRobinAssigner.Details details = new RoundRobinAssigner.Details();
-    if (input.recordsToRoundRobin.isEmpty() == false) {
+    if (input.optionalName != null) {
+      details.assignmentType = input.optionalName;
+    } else if (input.recordsToRoundRobin.isEmpty() == false) {
       details.assignmentType = input.recordsToRoundRobin[0].getSObjectType().getDescribe().getName() + '.' + input.ownerFieldApiName;
     } else {
       details.assignmentType = input.ownerFieldApiName;

--- a/core/classes/FlowRoundRobinAssignerTests.cls
+++ b/core/classes/FlowRoundRobinAssignerTests.cls
@@ -73,4 +73,16 @@ private class FlowRoundRobinAssignerTests {
 
     System.assertEquals(UserInfo.getUserId(), input.recordToRoundRobin.get('OwnerId'));
   }
+
+  @IsTest
+  static void usesCustomNameWhenSupplied() {
+    FlowRoundRobinAssigner.FlowInput input = new FlowRoundRobinAssigner.FlowInput();
+    input.recordToRoundRobin = new ContactPointAddress();
+    input.optionalName = 'Some name';
+    input.queryToRetrieveAssignees = 'SELECT Id FROM User WHERE Id = \'' + UserInfo.getUserId() + '\'';
+
+    FlowRoundRobinAssigner.assign(new List<FlowRoundRobinAssigner.FlowInput>{ input });
+
+    System.assertEquals(1, [SELECT COUNT() FROM RoundRobin__c WHERE Name = :input.optionalName]);
+  }
 }

--- a/core/classes/RoundRobinAssignerTests.cls
+++ b/core/classes/RoundRobinAssignerTests.cls
@@ -61,6 +61,20 @@ private class RoundRobinAssignerTests {
     }
   }
 
+  @IsTest
+  static void shouldNotFailWhenRoundRobinNameOverCustomSettingLimit() {
+    String assignmentType = '0'.repeat(256);
+    List<User> users = createUsersForAssignment(assignmentType);
+
+    Lead lead = new Lead();
+
+    RoundRobinAssigner.Details details = new RoundRobinAssigner.Details();
+    details.assignmentType = assignmentType;
+    new RoundRobinAssigner(new MockUserAssignmentRepo(users), details).assignOwners(new List<Lead>{ lead });
+
+    System.assertEquals(users[0].Id, lead.OwnerId);
+  }
+
   static List<User> createUsersForAssignment(String assignmentType) {
     List<User> users = new List<User>();
     String baseIdString = Schema.User.SObjectType.getDescribe(SObjectDescribeOptions.DEFERRED).getKeyPrefix() + '0'.repeat(11);

--- a/core/classes/RoundRobinRepository.cls
+++ b/core/classes/RoundRobinRepository.cls
@@ -62,17 +62,26 @@ public without sharing class RoundRobinRepository {
         }
         lockedAssignment.Index__c = assignment.Index__c;
         lockedAssignment.LastUpdated__c = assignment.LastUpdated__c;
-        update lockedAssignment;
-        // purely for the map assignment, below
         assignment = lockedAssignment;
+        this.write(assignment);
+        // purely for the map assignment, below
       } catch (DmlException ex) {
         return false;
       }
     } else {
-      insert assignment;
+      this.write(assignment);
     }
 
     CACHED_ASSIGNMENTS.put(assignment.Name, assignment);
     return true;
+  }
+
+  private void write(RoundRobin__c setting) {
+    // field truncation with Database.DMLOptions doesn't work with custom settings
+    final Integer customSettingNameMaxLength = 38;
+    if (setting.Name.length() > customSettingNameMaxLength) {
+      setting.Name = setting.Name.substring(0, customSettingNameMaxLength);
+    }
+    Database.upsert(setting); // NOPMD
   }
 }

--- a/core/classes/RoundRobinRepository.cls
+++ b/core/classes/RoundRobinRepository.cls
@@ -62,9 +62,9 @@ public without sharing class RoundRobinRepository {
         }
         lockedAssignment.Index__c = assignment.Index__c;
         lockedAssignment.LastUpdated__c = assignment.LastUpdated__c;
+        // purely for the map assignment, below
         assignment = lockedAssignment;
         this.write(assignment);
-        // purely for the map assignment, below
       } catch (DmlException ex) {
         return false;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-round-robin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Round robin records in Salesforce (SFDC) using Flow or Apex. Performant, fair, fast assignment with configurable user pools",
   "repository": {
     "type": "git",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -5,8 +5,8 @@
       "definitionFile": "config/project-scratch-def.json",
       "package": "salesforce-round-robin",
       "path": "core",
-      "versionName": "Removes platform cache due to inconsistent cache update behavior",
-      "versionNumber": "0.1.4.0",
+      "versionName": "Fixes truncation issue on Round Robin custom setting",
+      "versionNumber": "0.1.5.0",
       "versionDescription": "Invocable & Apex-ready Round Robin Assigner for Salesforce Flow, Process Builder, Apex and more",
       "releaseNotesUrl": "https://github.com/jamessimone/salesforce-round-robin/releases/latest"
     },
@@ -19,9 +19,6 @@
   "sourceApiVersion": "58.0",
   "packageAliases": {
     "salesforce-round-robin": "0Ho6g000000GnClCAK",
-    "salesforce-round-robin@0.1.0-0": "04t6g000008SjpyAAC",
-    "salesforce-round-robin@0.1.1-0": "04t6g000008fjhFAAQ",
-    "salesforce-round-robin@0.1.2-0": "04t6g000008fjhyAAA",
     "salesforce-round-robin@0.1.3": "04t6g000008C6lwAAC",
     "salesforce-round-robin@0.1.4": "04t6g000008C6sAAAS"
   }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -20,6 +20,7 @@
   "packageAliases": {
     "salesforce-round-robin": "0Ho6g000000GnClCAK",
     "salesforce-round-robin@0.1.3": "04t6g000008C6lwAAC",
-    "salesforce-round-robin@0.1.4": "04t6g000008C6sAAAS"
+    "salesforce-round-robin@0.1.4": "04t6g000008C6sAAAS",
+    "salesforce-round-robin@0.1.5": "04t6g000008Oa2hAAC"
   }
 }


### PR DESCRIPTION
* Fixes #16 by correctly truncating `RoundRobin__c.Name` when over the 38 character limit for custom setting names